### PR TITLE
use malicious `debug` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -243,7 +243,7 @@
       "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "debug": {
-      "version": "2.6.9",
+      "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {


### PR DESCRIPTION
The `package-lock.json` isn't valid anymore, but it doesn't matter for the SCA scanner, we still end up with the 4.4.2 version in the SBOM later and can demo it.

It's https://nvd.nist.gov/vuln/detail/CVE-2025-59144 FWIW.